### PR TITLE
refactor: amend NewWorldCoordinateSystem to accept WCSParams type in @observerly/skysolve

### DIFF
--- a/pkg/solver/solver.go
+++ b/pkg/solver/solver.go
@@ -509,18 +509,28 @@ func (ps *PlateSolver) Solve(tolerance geometry.InvariantFeatureTolerance) (*wcs
 	// Calculate the y-coordinate of the center of the image:
 	y := float64(ps.Height) / 2
 
+	// Create the affine parameters:
+	affineParams := transform.Affine2DParameters{
+		A: params[0],
+		B: params[1],
+		C: params[3],
+		D: params[4],
+		E: params[2],
+		F: params[5],
+	}
+
+	// Create the SIP parameters:
+	sipParams := transform.SIP2DParameters{}
+
 	// Now that we have the affine parameters, we can calculate the actual RA and dec coordinate
 	// for the center of the image:
 	t := wcs.NewWorldCoordinateSystem(
 		x,
 		y,
-		transform.Affine2DParameters{
-			A: params[0],
-			B: params[1],
-			C: params[3],
-			D: params[4],
-			E: params[2],
-			F: params[5],
+		wcs.WCSParams{
+			Projection:   wcs.RADEC_TAN,
+			AffineParams: affineParams,
+			SIPParams:    sipParams,
 		},
 	)
 

--- a/pkg/wcs/wcs.go
+++ b/pkg/wcs/wcs.go
@@ -87,7 +87,10 @@ type WCS struct {
 
 /*****************************************************************************************************************/
 
-func NewWorldCoordinateSystem(xc float64, yc float64, params transform.Affine2DParameters) WCS {
+func NewWorldCoordinateSystem(xc float64, yc float64, params WCSParams) WCS {
+	// Get the coordinate projection types, e.g., "RA---TAN", or "RA---TAN-SIP":
+	ctypes := params.Projection.ToCTypes()
+
 	// Create a new WCS object:
 	wcs := WCS{
 		WCAXES: 2, // We always assume two world coordinate axes, RA and Dec.
@@ -95,16 +98,16 @@ func NewWorldCoordinateSystem(xc float64, yc float64, params transform.Affine2DP
 		CRPIX2: float64(yc),
 		CRVAL1: 0,
 		CRVAL2: 0,
-		CUNIT1: "deg",      // We always assume degrees.
-		CUNIT2: "deg",      // We always assume degrees.
-		CTYPE1: "RA---TAN", // We always assume a tangential projection.
-		CTYPE2: "DEC--TAN", // We always assume a tangential projection.
-		CD1_1:  params.A,
-		CD1_2:  params.B,
-		CD2_1:  params.C,
-		CD2_2:  params.D,
-		E:      params.E,
-		F:      params.F,
+		CUNIT1: "deg", // We always assume degrees.
+		CUNIT2: "deg", // We always assume degrees.
+		CTYPE1: ctypes.CType1,
+		CTYPE2: ctypes.CType2,
+		CD1_1:  params.AffineParams.A,
+		CD1_2:  params.AffineParams.B,
+		CD2_1:  params.AffineParams.C,
+		CD2_2:  params.AffineParams.D,
+		E:      params.AffineParams.E,
+		F:      params.AffineParams.F,
 	}
 
 	// Calculate the reference equatorial coordinate:

--- a/pkg/wcs/wcs_test.go
+++ b/pkg/wcs/wcs_test.go
@@ -19,13 +19,34 @@ import (
 /*****************************************************************************************************************/
 
 func TestNewWCS(t *testing.T) {
-	wcs := NewWorldCoordinateSystem(1000, 1000, transform.Affine2DParameters{
+	affine := transform.Affine2DParameters{
 		A: 1,
 		B: 0,
 		C: 0,
 		D: 1,
 		E: 0,
 		F: 0,
+	}
+
+	sip := transform.SIP2DParameters{
+		AOrder: 1,
+		BOrder: 1,
+		APower: map[string]float64{
+			"0_0": 1,
+			"1_0": 0,
+			"0_1": 0,
+		},
+		BPower: map[string]float64{
+			"0_0": 1,
+			"1_0": 0,
+			"0_1": 0,
+		},
+	}
+
+	wcs := NewWorldCoordinateSystem(1000, 1000, WCSParams{
+		AffineParams: affine,
+		Projection:   RADEC_TAN,
+		SIPParams:    sip,
 	})
 
 	if wcs.CRPIX1 != 1000 {


### PR DESCRIPTION
refactor: amend NewWorldCoordinateSystem to accept WCSParams type in @observerly/skysolve