### PR TITLE
refactor!: amend to SIP2DForwardParameters usage across @observerly/skysolve

### DIFF
--- a/pkg/transform/sip.go
+++ b/pkg/transform/sip.go
@@ -15,7 +15,11 @@ package transform
 // Coordinate System (WCS) by introducing higher-order polynomial terms that account for non-linear
 // optical distortions, such as those introduced by telescope optics or atmospheric effects.
 // @see https://fits.gsfc.nasa.gov/registry/sip/SIP_distortion_v1_0.pdf
-type SIP2DParameters struct {
+
+/*****************************************************************************************************************/
+
+// The forward parameters are polynomial coefficients used to map from pixel coordinates to world coordinates.
+type SIP2DForwardParameters struct {
 	AOrder int
 	APower map[string]float64
 	BOrder int
@@ -24,6 +28,7 @@ type SIP2DParameters struct {
 
 /*****************************************************************************************************************/
 
+// The inverse paramaters are polynomial coefficients used to map from world coordinates to pixel coordinates.
 type SIP2DInverseParameters struct {
 	APOrder int
 	APPower map[string]float64

--- a/pkg/transform/sip_test.go
+++ b/pkg/transform/sip_test.go
@@ -14,8 +14,8 @@ import "testing"
 
 /*****************************************************************************************************************/
 
-func TestSIP2DParameters(t *testing.T) {
-	sip := SIP2DParameters{
+func TestSIP2DForwardParameters(t *testing.T) {
+	sip := SIP2DForwardParameters{
 		AOrder: 1,
 		BOrder: 1,
 		APower: map[string]float64{

--- a/pkg/wcs/wcs.go
+++ b/pkg/wcs/wcs.go
@@ -62,7 +62,7 @@ func (c CoordinateProjectionType) ToCTypes() CTypeP {
 type WCSParams struct {
 	Projection       CoordinateProjectionType         // Projection type e.g., "TAN", or "TAN-SIP"
 	AffineParams     transform.Affine2DParameters     // Affine transformation parameters
-	SIPParams        transform.SIP2DParameters        // SIP transformation (distortion) coefficients, x, y to RA, Dec
+	SIPForwardParams transform.SIP2DForwardParameters // SIP forward transformation (distortion) coefficients, x, y to RA, Dec
 	SIPInverseParams transform.SIP2DInverseParameters // SIP inverse transformation (distortion) coefficients RA, Dec to x, y
 }
 
@@ -86,7 +86,7 @@ type WCS struct {
 	CD2_2  float64                          `hdu:"CD2_2"`                     // Affine transform parameter D (no default)
 	E      float64                          `hdu:"E"`                         // Affine translation parameter e (optional, no default)
 	F      float64                          `hdu:"F"`                         // Affine translation parameter f (optional, no default)
-	SIP    transform.SIP2DParameters        ``                                // SIP transformation (distortion) coefficients
+	FSIP   transform.SIP2DForwardParameters ``                                // SIP forward transformation (distortion) coefficients
 	ISIP   transform.SIP2DInverseParameters ``                                // SIP inverse transformation (distortion) coefficients
 }
 
@@ -113,7 +113,7 @@ func NewWorldCoordinateSystem(xc float64, yc float64, params WCSParams) WCS {
 		CD2_2:  params.AffineParams.D,
 		E:      params.AffineParams.E,
 		F:      params.AffineParams.F,
-		SIP:    params.SIPParams,
+		FSIP:   params.SIPForwardParams,
 		ISIP:   params.SIPInverseParams,
 	}
 
@@ -168,7 +168,7 @@ func (wcs *WCS) PixelToEquatorialCoordinate(
 	B := 0.0
 
 	// Apply A polynomial corrections:
-	for term, coeff := range wcs.SIP.APower {
+	for term, coeff := range wcs.FSIP.APower {
 		i, j, err := parseSIPTerm(term, "A")
 		if err != nil {
 			continue
@@ -177,7 +177,7 @@ func (wcs *WCS) PixelToEquatorialCoordinate(
 	}
 
 	// Apply B polynomial corrections:
-	for term, coeff := range wcs.SIP.BPower {
+	for term, coeff := range wcs.FSIP.BPower {
 		i, j, err := parseSIPTerm(term, "B")
 		if err != nil {
 			continue

--- a/pkg/wcs/wcs_test.go
+++ b/pkg/wcs/wcs_test.go
@@ -29,7 +29,7 @@ func TestNewWCS(t *testing.T) {
 		F: 0,
 	}
 
-	sip := transform.SIP2DParameters{
+	fsip := transform.SIP2DForwardParameters{
 		AOrder: 1,
 		BOrder: 1,
 		APower: map[string]float64{
@@ -45,9 +45,9 @@ func TestNewWCS(t *testing.T) {
 	}
 
 	wcs := NewWorldCoordinateSystem(1000, 1000, WCSParams{
-		AffineParams: affine,
-		Projection:   RADEC_TAN,
-		SIPParams:    sip,
+		AffineParams:     affine,
+		Projection:       RADEC_TAN,
+		SIPForwardParams: fsip,
 	})
 
 	if wcs.CRPIX1 != 1000 {
@@ -160,7 +160,7 @@ func TestPixelToEquatorialCoordinate(t *testing.T) {
 /*****************************************************************************************************************/
 
 func TestPixelToEquatorialCoordinateWithSIPDistortionAtImageCenter(t *testing.T) {
-	sip := transform.SIP2DParameters{
+	fsip := transform.SIP2DForwardParameters{
 		AOrder: 3,
 		BOrder: 3,
 		APower: map[string]float64{
@@ -192,7 +192,7 @@ func TestPixelToEquatorialCoordinateWithSIPDistortionAtImageCenter(t *testing.T)
 		CD1_2:  0.0,           // No rotation
 		CD2_1:  0.0,           // No rotation
 		CD2_2:  0.0002777778,  // 1/3600 deg/pixel
-		SIP:    sip,
+		FSIP:   fsip,
 	}
 
 	coordinate := wcs.PixelToEquatorialCoordinate(1024.0, 1024.0)
@@ -209,7 +209,7 @@ func TestPixelToEquatorialCoordinateWithSIPDistortionAtImageCenter(t *testing.T)
 /*****************************************************************************************************************/
 
 func TestPixelToEquatorialCoordinateWithSIPDistortion(t *testing.T) {
-	sip := transform.SIP2DParameters{
+	fsip := transform.SIP2DForwardParameters{
 		AOrder: 3,
 		BOrder: 3,
 		APower: map[string]float64{
@@ -241,7 +241,7 @@ func TestPixelToEquatorialCoordinateWithSIPDistortion(t *testing.T) {
 		CD1_2:  0.0,           // No rotation
 		CD2_1:  0.0,           // No rotation
 		CD2_2:  0.0002777778,  // 1/3600 deg/pixel
-		SIP:    sip,
+		FSIP:   fsip,
 	}
 
 	coordinate := wcs.PixelToEquatorialCoordinate(1000.0, 1000.0)
@@ -314,7 +314,7 @@ func TestEquatorialCoordinateToPixel(t *testing.T) {
 /*****************************************************************************************************************/
 
 func TestEquatorialCoordinateToPixelWithSIPDistortionAtImageCenter(t *testing.T) {
-	sip := transform.SIP2DParameters{
+	fsip := transform.SIP2DForwardParameters{
 		AOrder: 3,
 		BOrder: 3,
 		APower: map[string]float64{
@@ -372,7 +372,7 @@ func TestEquatorialCoordinateToPixelWithSIPDistortionAtImageCenter(t *testing.T)
 		CD1_2:  0.0,           // No rotation
 		CD2_1:  0.0,           // No rotation
 		CD2_2:  0.0002777778,  // 1/3600 deg/pixel
-		SIP:    sip,
+		FSIP:   fsip,
 		ISIP:   isip,
 	}
 
@@ -394,7 +394,7 @@ func TestEquatorialCoordinateToPixelWithSIPDistortionAtImageCenter(t *testing.T)
 /*****************************************************************************************************************/
 
 func TestEquatorialCoordinateToPixelWithSIPDistortion(t *testing.T) {
-	sip := transform.SIP2DParameters{
+	fsip := transform.SIP2DForwardParameters{
 		AOrder: 3,
 		BOrder: 3,
 		APower: map[string]float64{
@@ -452,7 +452,7 @@ func TestEquatorialCoordinateToPixelWithSIPDistortion(t *testing.T) {
 		CD1_2:  0.0,           // No rotation
 		CD2_1:  0.0,           // No rotation
 		CD2_2:  0.0002777778,  // 1/3600 deg/pixel
-		SIP:    sip,
+		FSIP:   fsip,
 		ISIP:   isip,
 	}
 


### PR DESCRIPTION
refactor!: amend to SIP2DForwardParameters usage across @observerly/skysolve

---

This improves the naming convention around SIP parameters, making them much more human readable.