### PR TITLE
feat: add SimulatedSkyImage struct to sky module in @observerly/skysolve

### DIFF
--- a/pkg/sky/sky.go
+++ b/pkg/sky/sky.go
@@ -12,6 +12,8 @@ package sky
 
 import (
 	"time"
+
+	"github.com/observerly/skysolve/pkg/wcs"
 )
 
 /*****************************************************************************************************************/
@@ -32,6 +34,33 @@ type Params struct {
 	SkyBackground            float64       // the sky background in units of e-/m2/arcsec2/s
 	Seeing                   float64       // the perceived seeing in units of arcsec
 	AverageQuantumEfficiency float64       // the average quantum efficiency of the CCD
+}
+
+/*****************************************************************************************************************/
+
+type SimulatedSkyImage struct {
+	RA                       float64
+	Dec                      float64
+	WCS                      wcs.WCS
+	Width                    int
+	Height                   int
+	ExposureDuration         float64
+	MaxADU                   float64
+	BiasOffset               float64
+	Gain                     float64
+	ReadNoise                float64
+	DarkCurrent              float64
+	BinningX                 int
+	BinningY                 int
+	PixelSizeX               float64
+	PixelSizeY               float64
+	PixelScaleX              float64
+	PixelScaleY              float64
+	FocalLength              float64
+	ApertureDiameter         float64
+	SkyBackground            float64
+	Seeing                   float64
+	AverageQuantumEfficiency float64
 }
 
 /*****************************************************************************************************************/


### PR DESCRIPTION
feat: add SimulatedSkyImage struct to sky module in @observerly/skysolve