### PR TITLE
feat: add DetermineABCD to quad module in @observerly/skysolve

### DIFF
--- a/pkg/quad/quad.go
+++ b/pkg/quad/quad.go
@@ -11,6 +11,7 @@ package quad
 /*****************************************************************************************************************/
 
 import (
+	"github.com/observerly/skysolve/pkg/geometry"
 	"github.com/observerly/skysolve/pkg/star"
 )
 
@@ -39,6 +40,49 @@ type Quad struct {
 type QuadMatch struct {
 	StarQaud   Quad
 	SourceQuad Quad
+}
+
+/*****************************************************************************************************************/
+
+// DetermineAB determines which points are A and B based on the criteria that A and B are the two points
+// with the largest distance between all of the points in the quad.
+// C is then the point that is closest to A in the x dimension, e.g., Cx < Dx.
+func DetermineABCD(a, b, c, d star.Star) (star.Star, star.Star, star.Star, star.Star) {
+	stars := []star.Star{a, b, c, d}
+	maximum := -1.0
+	var A, B star.Star
+
+	// Find the pair with the maximum distance in the quad:
+	for i := 0; i < len(stars); i++ {
+		for j := i + 1; j < len(stars); j++ {
+			distance := geometry.DistanceBetweenTwoCartesianPoints(stars[i].X, stars[i].Y, stars[j].X, stars[j].Y)
+
+			if distance > maximum {
+				maximum = distance
+				// Assign A and B based on X coordinate such that Ax < Bx:
+				if stars[i].X < stars[j].X {
+					A, B = stars[i], stars[j]
+				} else {
+					A, B = stars[j], stars[i]
+				}
+			}
+		}
+	}
+
+	// Assign C and D as the remaining stars in the quad:
+	var remaining []star.Star
+	for _, s := range stars {
+		if s != A && s != B {
+			remaining = append(remaining, s)
+		}
+	}
+
+	// Ensure Cx < Dx by swapping if necessary:
+	if remaining[0].X < remaining[1].X {
+		return A, B, remaining[0], remaining[1]
+	}
+
+	return A, B, remaining[1], remaining[0]
 }
 
 /*****************************************************************************************************************/


### PR DESCRIPTION
feat: add DetermineABCD to quad module in @observerly/skysolve

---

This algorithm ensures we adhere to the normalisation of quadrants of stars using Lang et al. 2010.

<img width="372" alt="Screenshot 2024-11-30 at 16 16 11" src="https://github.com/user-attachments/assets/7f31b16a-4252-4133-b80f-51634853dfea">
