### PR TITLE
style: remove usage of fmt.Println across tests files in @observerly/skysolve

### DIFF
--- a/pkg/catalog/simbad_test.go
+++ b/pkg/catalog/simbad_test.go
@@ -9,7 +9,6 @@
 package catalog
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/observerly/skysolve/pkg/astrometry"
@@ -38,8 +37,6 @@ func TestSIMBADQueryExecutedSuccessfully(t *testing.T) {
 		if !IsWithinICRSPolarRadius(star.RA, star.Dec, 2.5) {
 			t.Errorf("Star is not within the search radius")
 		}
-
-		fmt.Println(star.Designation)
 	}
 
 	// The SIMBAD catalog is expected to return a maximum of 100 stars for this query:

--- a/pkg/wcs/wcs_test.go
+++ b/pkg/wcs/wcs_test.go
@@ -11,7 +11,6 @@ package wcs
 /*****************************************************************************************************************/
 
 import (
-	"fmt"
 	"math"
 	"testing"
 
@@ -462,8 +461,6 @@ func TestEquatorialCoordinateToPixelWithSIPDistortion(t *testing.T) {
 	x, y := wcs.EquatorialCoordinateToPixel(coordinate.RA, coordinate.Dec)
 
 	tolerance := 0.001
-
-	fmt.Println(x, y)
 
 	if math.Abs((x + 24)) > tolerance {
 		t.Errorf("X not calculated correctly")


### PR DESCRIPTION
…skysolve

style: remove usage of fmt.Println across tests files in @observerly/skysolve