### PR TITLE
fix!: amend EquatorialCoordinateToPixel in wcs module in @observerly/skysolve

### DIFF
--- a/pkg/wcs/wcs.go
+++ b/pkg/wcs/wcs.go
@@ -291,8 +291,8 @@ func (wcs *WCS) EquatorialCoordinateToPixel(
 	deltaY += B
 
 	// Add the reference pixel coordinates to obtain final pixel positions
-	x = deltaX
-	y = deltaY
+	x = deltaX + wcs.CRPIX1
+	y = deltaY + wcs.CRPIX2
 
 	return x, y
 }

--- a/pkg/wcs/wcs_test.go
+++ b/pkg/wcs/wcs_test.go
@@ -273,11 +273,11 @@ func TestEquatorialCoordinateToPixelAtImageCenter(t *testing.T) {
 
 	tolerance := 0.0000001
 
-	if math.Abs((x - 0)) > tolerance {
+	if math.Abs((x - 1024)) > tolerance {
 		t.Errorf("X not calculated correctly")
 	}
 
-	if math.Abs(y-0) > tolerance {
+	if math.Abs(y-1024) > tolerance {
 		t.Errorf("Y not calculated correctly")
 	}
 }
@@ -382,11 +382,11 @@ func TestEquatorialCoordinateToPixelWithSIPDistortionAtImageCenter(t *testing.T)
 
 	tolerance := 0.0000001
 
-	if math.Abs((x)) > tolerance {
+	if math.Abs((x - 1024)) > tolerance {
 		t.Errorf("X not calculated correctly")
 	}
 
-	if math.Abs(y) > tolerance {
+	if math.Abs((y - 1024)) > tolerance {
 		t.Errorf("Y not calculated correctly")
 	}
 }
@@ -462,11 +462,11 @@ func TestEquatorialCoordinateToPixelWithSIPDistortion(t *testing.T) {
 
 	tolerance := 0.001
 
-	if math.Abs((x + 24)) > tolerance {
+	if math.Abs((x - 1000)) > tolerance {
 		t.Errorf("X not calculated correctly")
 	}
 
-	if math.Abs(y+24) > tolerance {
+	if math.Abs(y-1000) > tolerance {
 		t.Errorf("Y not calculated correctly")
 	}
 }


### PR DESCRIPTION
fix!: amend EquatorialCoordinateToPixel in wcs module in @observerly/skysolve