### PR TITLE
feat: add ExtractImageWidthFromHeaders to internal/utils module in @observerly/skysolve

### DIFF
--- a/internal/utils/headers.go
+++ b/internal/utils/headers.go
@@ -76,3 +76,21 @@ func ResolveOrExtractDecFromHeaders(value float32, header fits.FITSHeader) (floa
 }
 
 /*****************************************************************************************************************/
+
+func ExtractImageWidthFromHeaders(header fits.FITSHeader) (int32, error) {
+	// Attempt to get the width header from the FITS file:
+	width, exists := header.Ints["NAXIS1"]
+	if !exists {
+		return -1, fmt.Errorf("width header not found in the supplied FITS file")
+	}
+
+	// Validate the width is within the range [0, ∞):
+	if width.Value <= 0 || width.Value == math.MaxInt32 {
+		return -1, fmt.Errorf("width value is out of range: %v", width.Value)
+	}
+
+	// Return the width:
+	return width.Value, nil
+}
+
+/*****************************************************************************************************************/

--- a/internal/utils/headers_test.go
+++ b/internal/utils/headers_test.go
@@ -278,3 +278,78 @@ func TestDecValueIsNaNAndDecHeaderNaN(t *testing.T) {
 }
 
 /*****************************************************************************************************************/
+
+func TestWidthIsPresentAndValid(t *testing.T) {
+	header := fits.FITSHeader{
+		Ints: map[string]fits.FITSHeaderInt{
+			"NAXIS1": {
+				Value:   1024,
+				Comment: "Width of the image",
+			},
+		},
+	}
+
+	got, err := ExtractImageWidthFromHeaders(header)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	expected := int32(1024)
+	if got != expected {
+		t.Errorf("Expected %d, got %d", expected, got)
+	}
+}
+
+func TestWidthIsMissingFromHeader(t *testing.T) {
+	header := fits.FITSHeader{
+		Ints: map[string]fits.FITSHeaderInt{},
+	}
+
+	got, err := ExtractImageWidthFromHeaders(header)
+	if err == nil {
+		t.Fatalf("Expected an error for missing width, but got none")
+	}
+	if got != -1 {
+		t.Errorf("Expected -1 for missing width, got %d", got)
+	}
+}
+
+func TestWidthIsOutOfRangeZeroOrNegative(t *testing.T) {
+	header := fits.FITSHeader{
+		Ints: map[string]fits.FITSHeaderInt{
+			"NAXIS1": {
+				Value:   -100,
+				Comment: "Width of the image",
+			},
+		},
+	}
+
+	got, err := ExtractImageWidthFromHeaders(header)
+	if err == nil {
+		t.Fatalf("Expected an error for width <= 0, but got none")
+	}
+	if got != -1 {
+		t.Errorf("Expected -1 for invalid width, got %d", got)
+	}
+}
+
+func TestWidthIsOutOfRangeMaxInt32(t *testing.T) {
+	header := fits.FITSHeader{
+		Ints: map[string]fits.FITSHeaderInt{
+			"NAXIS1": {
+				Value:   math.MaxInt32,
+				Comment: "Width of the image",
+			},
+		},
+	}
+
+	got, err := ExtractImageWidthFromHeaders(header)
+	if err == nil {
+		t.Fatalf("Expected an error for width == math.MaxInt32, but got none")
+	}
+	if got != -1 {
+		t.Errorf("Expected -1 for invalid width, got %d", got)
+	}
+}
+
+/*****************************************************************************************************************/


### PR DESCRIPTION
feat: add ExtractImageWidthFromHeaders to internal/utils module in @observerly/skysolve