### PR TITLE
feat: add ExtractImageHeightFromHeaders to internal/utils module in @observerly/skysolve

### DIFF
--- a/internal/utils/headers.go
+++ b/internal/utils/headers.go
@@ -94,3 +94,21 @@ func ExtractImageWidthFromHeaders(header fits.FITSHeader) (int32, error) {
 }
 
 /*****************************************************************************************************************/
+
+func ExtractImageHeightFromHeaders(header fits.FITSHeader) (int32, error) {
+	// Attempt to get the height header from the FITS file:
+	height, exists := header.Ints["NAXIS2"]
+	if !exists {
+		return -1, fmt.Errorf("height header not found in the supplied FITS file")
+	}
+
+	// Validate the height is within the range [0, ∞):
+	if height.Value <= 0 || height.Value == math.MaxInt32 {
+		return -1, fmt.Errorf("height value is out of range: %v", height.Value)
+	}
+
+	// Return the height:
+	return height.Value, nil
+}
+
+/*****************************************************************************************************************/

--- a/internal/utils/headers_test.go
+++ b/internal/utils/headers_test.go
@@ -353,3 +353,78 @@ func TestWidthIsOutOfRangeMaxInt32(t *testing.T) {
 }
 
 /*****************************************************************************************************************/
+
+func TestHeightIsPresentAndValid(t *testing.T) {
+	header := fits.FITSHeader{
+		Ints: map[string]fits.FITSHeaderInt{
+			"NAXIS2": {
+				Value:   1024,
+				Comment: "Height of the image",
+			},
+		},
+	}
+
+	got, err := ExtractImageHeightFromHeaders(header)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	expected := int32(1024)
+	if got != expected {
+		t.Errorf("Expected %d, got %d", expected, got)
+	}
+}
+
+func TestHeightIsMissingFromHeader(t *testing.T) {
+	header := fits.FITSHeader{
+		Ints: map[string]fits.FITSHeaderInt{},
+	}
+
+	got, err := ExtractImageHeightFromHeaders(header)
+	if err == nil {
+		t.Fatalf("Expected an error for missing height, but got none")
+	}
+	if got != -1 {
+		t.Errorf("Expected -1 for missing height, got %d", got)
+	}
+}
+
+func TestHeightIsOutOfRangeZeroOrNegative(t *testing.T) {
+	header := fits.FITSHeader{
+		Ints: map[string]fits.FITSHeaderInt{
+			"NAXIS2": {
+				Value:   -100,
+				Comment: "Height of the image",
+			},
+		},
+	}
+
+	got, err := ExtractImageHeightFromHeaders(header)
+	if err == nil {
+		t.Fatalf("Expected an error for height <= 0, but got none")
+	}
+	if got != -1 {
+		t.Errorf("Expected -1 for invalid height, got %d", got)
+	}
+}
+
+func TestHeightIsOutOfRangeMaxInt32(t *testing.T) {
+	header := fits.FITSHeader{
+		Ints: map[string]fits.FITSHeaderInt{
+			"NAXIS2": {
+				Value:   math.MaxInt32,
+				Comment: "Height of the image",
+			},
+		},
+	}
+
+	got, err := ExtractImageHeightFromHeaders(header)
+	if err == nil {
+		t.Fatalf("Expected an error for height == math.MaxInt32, but got none")
+	}
+	if got != -1 {
+		t.Errorf("Expected -1 for invalid height, got %d", got)
+	}
+}
+
+/*****************************************************************************************************************/


### PR DESCRIPTION
feat: add ExtractImageHeightFromHeaders to internal/utils module in @observerly/skysolve